### PR TITLE
Priority Projects

### DIFF
--- a/css/item_table.css
+++ b/css/item_table.css
@@ -179,6 +179,10 @@ img.quest-item-image {
     border-radius: 4px;
 }
 
+img.priority-quest-item {
+    box-shadow: 0 0 2px 2px rgba(255, 0, 0, 1.0);
+}
+
 .quest-percent-text {
     text-shadow: 1px 1px 4px #000000,
     1px 1px 4px #000000,

--- a/index.html
+++ b/index.html
@@ -271,6 +271,9 @@
             <button id="project-add-button" disabled type="button" onclick="add_project_data()"><span translate_text="projects_tab.add_project_items_button">Add Project Items</span></button>
             <button id="project-sub-button" disabled type="button" onclick="sub_project_data()"><span translate_text="projects_tab.subtract_project_items_button">Subtract Project Items</span></button>
             <button id="project-delete-button" type="button" onclick="delete_project_data()"><span translate_text="projects_tab.delete_project_button">Delete Project</span></button>
+            <br><br>
+            <button id="prioritize-project-button" disabled type="button" onclick="prioritize_selected_project(true)"><span translate_text="projects_tab.prioritize_project_button">Prioritize Project</span></button>
+            <button id="deprioritize-project-button" disabled hidden type="button" onclick="prioritize_selected_project(false)"><span translate_text="projects_tab.deprioritize_project_button">Deprioritize Project</span></button>
             <br><br><br>
             <button type="button" onclick="clear_all_item_tables()"><span translate_text="projects_tab.clear_item_tables_button">Clear Item Tables</span></button>
         </div>

--- a/language/en.json
+++ b/language/en.json
@@ -68,6 +68,8 @@
     "add_project_items_button": "Add Project Items",
     "subtract_project_items_button": "Subtract Project Items",
     "delete_project_button": "Delete Project",
+    "prioritize_project_button": "Prioritize Project",
+    "deprioritize_project_button": "Deprioritize Project",
 
     "clear_item_tables_button": "Clear Item Tables",
 

--- a/language/ko.json
+++ b/language/ko.json
@@ -68,6 +68,8 @@
     "add_project_items_button": "프로젝트 아이템 추가",
     "subtract_project_items_button": "프로젝트 아이템 제거",
     "delete_project_button": "프로젝트 제거",
+    "prioritize_project_button": "Prioritize Project",
+    "deprioritize_project_button": "Deprioritize Project",
 
     "clear_item_tables_button": "아이템 표 비우기",
 

--- a/pages/export-data/index.html
+++ b/pages/export-data/index.html
@@ -124,10 +124,12 @@
 
 <script>
     let project_data;
+    let priority_project_data;
     let blacklist_data;
     let settings_data;
 
     let project_json;
+    let priority_project_json;
     let blacklist_json;
     let settings_json;
 
@@ -202,10 +204,12 @@
         try
         {
             project_data = localStorage.getItem('projects');
+            priority_project_data = localStorage.getItem('priority_projects');
             blacklist_data = localStorage.getItem('blacklist');
             settings_data = localStorage.getItem('settings');
 
             project_json = (project_data !== null ? JSON.parse(project_data) : "");
+            priority_project_json = (priority_project_data !== null ? JSON.parse(priority_project_data) : "");
             blacklist_json = (blacklist_data !== null ? JSON.parse(blacklist_data) : "");
             settings_json = (settings_data !== null ? JSON.parse(settings_data) : "");
 
@@ -275,7 +279,14 @@
 
                 let content;
                 let content_map = new Map();
-                if (include_projects) { content_map["projects"] = localStorage.getItem('projects'); }
+                if (include_projects)
+                {
+                    content_map["projects"] = localStorage.getItem('projects');
+                    if (priority_project_data !== null)
+                    {
+                        content_map["priority_projects"] = localStorage.getItem('priority_projects');
+                    }
+                }
                 else if (project_data !== null) { document.getElementById("project-display").style.display = "none"; }
                 if (include_blacklist) { content_map["blacklist"] = localStorage.getItem('blacklist'); }
                 else if (blacklist_data !== null) { document.getElementById("blacklist-display").style.display = "none"; }

--- a/pages/import-data/index.html
+++ b/pages/import-data/index.html
@@ -118,11 +118,13 @@
 
 <script>
     let project_data;
+    let priority_project_data;
     let blacklist_data;
     let settings_data;
     let gist_id;
 
     let project_json;
+    let priority_project_json;
     let blacklist_json;
     let settings_json;
 
@@ -164,16 +166,19 @@
                             // EXTRACT DATA FROM GIST
                             let converted_gist_data = JSON.parse(gist_data);
                             project_data = converted_gist_data["projects"];
+                            priority_project_data = converted_gist_data["priority_projects"];
                             blacklist_data = converted_gist_data["blacklist"];
                             settings_data = converted_gist_data["settings"];
 
                             // CHECK IF ANY DATA IS MISSING/NOT PROVIDED
                             let include_projects = project_data !== undefined;
+                            let include_priority_projects = priority_project_data !== undefined;
                             let include_blacklist = blacklist_data !== undefined;
                             let include_settings = settings_data !== undefined;
 
                             // CONVERT DATA
                             project_json = (include_projects ? JSON.parse(project_data) : "");
+                            priority_project_json = (include_priority_projects ? JSON.parse(priority_project_data) : "");
                             blacklist_json = (include_blacklist ? JSON.parse(blacklist_data) : "");
                             settings_json = (include_settings ? JSON.parse(settings_data) : "");
 
@@ -233,6 +238,10 @@
         if (project_data !== undefined)
         {
             localStorage.setItem('projects', project_data);
+            if (priority_project_data !== undefined)
+            {
+                localStorage.setItem('priority_projects', priority_project_data);
+            }
         }
         if (blacklist_data !== undefined)
         {

--- a/pages/import-data/index.html
+++ b/pages/import-data/index.html
@@ -237,6 +237,7 @@
         // IMPORT DATA
         if (project_data !== undefined)
         {
+            localStorage.removeItem('priority_projects');
             localStorage.setItem('projects', project_data);
             if (priority_project_data !== undefined)
             {

--- a/scripts/language.js
+++ b/scripts/language.js
@@ -91,4 +91,7 @@ function change_language()
 
     // UPDATE UPDATE PROGRESS
     refresh_quest_update_language();
+
+    // DISABLE ADD/SUBTRACT/PRIORITIZE/DEPRIORITZE BUTTONS
+    disable_add_and_sub_buttons(true);
 }

--- a/scripts/language.js
+++ b/scripts/language.js
@@ -94,4 +94,5 @@ function change_language()
 
     // DISABLE ADD/SUBTRACT/PRIORITIZE/DEPRIORITZE BUTTONS
     disable_add_and_sub_buttons(true);
+    show_prioritize_button(true);
 }

--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -1,5 +1,7 @@
 let projects = new Map();
 let priority_projects = [];
+let priority_items_array = [];
+let priority_items_compiled = false;
 
 function init_project_data()
 {
@@ -29,6 +31,7 @@ function init_project_data()
         if (priority_project_cookie_data !== null)
         {
             // PRIORITY PROJECT COOKIE EXISTS, DECRYPT DATA AND SAVE TO GLOBAL VAR
+            // ALSO COMPILE LIST OF PRIORITY ITEMS FROM PRIORITY PROJECTS
 
             priority_projects = JSON.parse(priority_project_cookie_data);
         }
@@ -114,6 +117,9 @@ function save_project_data()
     document.getElementById("saved-projects-select").value = project_name;
     disable_add_and_sub_buttons(false);
     show_prioritize_button(true);
+
+    // UPDATE PRIORITY ITEMS
+    get_priority_items();
 
     if (current_language === "en")
     {
@@ -252,6 +258,7 @@ function delete_project_data()
         //Cookies.remove('projects');
         localStorage.removeItem('projects');
         localStorage.removeItem('priority_projects');
+        get_priority_items();
     }
 
     if (priority_projects.includes(project_name))
@@ -663,27 +670,29 @@ function show_prioritize_button(true_or_false)
 function prioritize_selected_project(true_or_false)
 {
     let selected_project = document.getElementById("saved-projects-select").value;
-
-    if (true_or_false)
+    if (selected_project !== "[All Projects...]")
     {
-        priority_projects.push(selected_project);
-    }
-    else
-    {
-        let index = priority_projects.indexOf(selected_project);
-        if (index > -1)
+        if (true_or_false)
         {
-            priority_projects.splice(index, 1);
+            priority_projects.push(selected_project);
         }
+        else
+        {
+            let index = priority_projects.indexOf(selected_project);
+            if (index > -1)
+            {
+                priority_projects.splice(index, 1);
+            }
+        }
+
+        show_prioritize_button(!true_or_false);
+        update_saved_projects_select();
+        document.getElementById("saved-projects-select").value = selected_project;
+
+        save_priority_projects();
+
+        console.log("[Priority Projects] - " + (true_or_false ? "Prioritized" : "Deprioritized") + " \"" + selected_project + "\"");
     }
-
-    show_prioritize_button(!true_or_false);
-    update_saved_projects_select();
-    document.getElementById("saved-projects-select").value = selected_project;
-
-    save_priority_projects();
-
-    console.log("[Priority Projects] - " + (true_or_false ? "Prioritized" : "Deprioritized") + " \"" + selected_project + "\"")
 }
 
 function save_priority_projects()
@@ -698,4 +707,5 @@ function save_priority_projects()
         // IF PRIORITY PROJECT LIST IS EMPTY, JUST DELETE FROM LOCAL STORAGE.
         localStorage.removeItem('priority_projects');
     }
+    get_priority_items();
 }

--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -110,9 +110,10 @@ function save_project_data()
     // UPDATE SELECT DISPLAYING SAVED PROJECTS
     update_saved_projects_select();
 
-    // SET SELECTED PROJECT TO RECENTLY SAVED PROJECT, ALSO ENABLE ADD/SUB BUTTONS
+    // SET SELECTED PROJECT TO RECENTLY SAVED PROJECT, ALSO ENABLE ADD/SUB BUTTONS AND SHOW PRIORITIZE BUTTON
     document.getElementById("saved-projects-select").value = project_name;
     disable_add_and_sub_buttons(false);
+    show_prioritize_button(true);
 
     if (current_language === "en")
     {
@@ -245,10 +246,12 @@ function delete_project_data()
     else
     {
         projects = new Map();
+        priority_projects = [];
 
         // DELETE COOKIE SINCE IT'S NOT NEEDED ANYMORE
         //Cookies.remove('projects');
         localStorage.removeItem('projects');
+        localStorage.removeItem('priority_projects');
     }
 
     if (priority_projects.includes(project_name))

--- a/scripts/recommended-quest-table.js
+++ b/scripts/recommended-quest-table.js
@@ -6,7 +6,7 @@ function build_recommended_quest_table(all_recipe_maps_array)
     let quest_table = document.getElementById("recommended-quest-table");
     let quests = quest_map;
 
-    /* REPLACE TOTAL RECIPE WITH TOTAL RECIPE W/O DISABLED COMPONENTS FROM RECIPE READER/REQUIRED INGREDIENTS TABLE */
+    // REPLACE TOTAL RECIPE WITH TOTAL RECIPE W/O DISABLED COMPONENTS FROM RECIPE READER/REQUIRED INGREDIENTS TABLE
     for (let i = 0 ; i < disabled_items.length ; i++)
     {
         if (total_recipe.has(disabled_items[i]))
@@ -14,6 +14,12 @@ function build_recommended_quest_table(all_recipe_maps_array)
             // DISABLED ITEM EXISTS IN TOTAL RECIPE, DELETE IT
             total_recipe.delete(disabled_items[i]);
         }
+    }
+
+    // COMPILE LIST OF PRIORITY ITEMS FROM PRIORITY PROJECTS
+    if (!priority_items_compiled)
+    {
+        get_priority_items();
     }
 
     /* OPEN OR CLOSE QUEST BOARD */
@@ -24,11 +30,12 @@ function build_recommended_quest_table(all_recipe_maps_array)
         /* ITERATE THROUGH ALL QUESTS, GENERATE QUEST SCORE */
         let quest_score_map = new Map();
 
-        const item_is_in_top_2_score = 1;
+        const item_is_in_top_2_score = 1.0;
         const item_is_in_3rd_slot = 0.75;
         const item_is_in_subitem_score = 0.5;
         const item_is_in_subitem17_score = 0.45;
         const item_is_in_subitem15_score = 0.40;
+        const priority_item_multiplier = 2.0;
 
         for (let [quest_id, quest_data] of quests)
         {
@@ -62,27 +69,45 @@ function build_recommended_quest_table(all_recipe_maps_array)
                     let item_1_dp = quest_data.get("item_1").drop_percent;      // OBJECT
                     let item_3_dp = quest_data.get("item_3").drop_percent;      // OBJECT
                     let quest_subdrops = quest_data.get("subdrops");            // ARRAY
-                    let q_subdrops_percent = quest_data.get("subdrops_percent");//ARRAY
+                    let q_subdrops_percent = quest_data.get("subdrops_percent");// ARRAY
                     let char_shard = "";
                     if (quest_id.includes("H")) { char_shard = quest_data.get("char_shard").item_name; } // OBJECT
 
                     let quest_score = 0;
 
                     // CHECK ITEM 1 - 3
-                    if (total_recipe.has(item_1_name)) { quest_score += item_is_in_top_2_score; }
-                    if (total_recipe.has(item_2_name)) { quest_score += item_is_in_top_2_score; }
+                    if (total_recipe.has(item_1_name))
+                    {
+                        //console.log(item_1_name);
+                        if (priority_items_array.includes(item_1_name)) {
+                            quest_score += (item_is_in_top_2_score * priority_item_multiplier);
+                            //console.log("multiplied.")
+                        }
+                        else {
+                            quest_score += item_is_in_top_2_score;
+                            //console.log("not multiplied.");
+                        }
+                    }
+                    if (total_recipe.has(item_2_name))
+                    {
+                        if (priority_items_array.includes(item_2_name)) { quest_score += item_is_in_top_2_score * priority_item_multiplier; }
+                        else { quest_score += item_is_in_top_2_score; }
+                    }
                     if (total_recipe.has(item_3_name))
                     {
+                        let score_to_be_added;
                         // IF ITEM 3 DROP PERCENT == ITEM 1 DROP PERCENT, GIVE SCORE EQUAL AS IF ITEM WAS IN TOP 2
                         if (item_1_dp === item_3_dp)
                         {
-                            quest_score += item_is_in_top_2_score;
+                            score_to_be_added = item_is_in_top_2_score;
                         }
                         else
                         {
-                            quest_score += item_is_in_3rd_slot;
+                            score_to_be_added = item_is_in_3rd_slot;
                         }
 
+                        if (priority_items_array.includes(item_3_name)) { quest_score += score_to_be_added * priority_item_multiplier; }
+                        else { quest_score += score_to_be_added; }
                     }
 
                     // CHECK SUBDROPS
@@ -92,34 +117,42 @@ function build_recommended_quest_table(all_recipe_maps_array)
                         {
                             if (q_subdrops_percent === undefined)
                             {
-                                quest_score += item_is_in_subitem_score;
+                                if (priority_items_array.includes(quest_subdrops[i])) { quest_score += item_is_in_subitem_score * priority_item_multiplier; }
+                                else { quest_score += item_is_in_subitem_score; }
                             }
                             else
                             {
+                                let score_to_be_added;
                                 switch (q_subdrops_percent[i])
                                 {
                                     case 24:
-                                        quest_score += item_is_in_3rd_slot;
+                                        score_to_be_added = item_is_in_3rd_slot;
                                         break;
                                     case 20:
-                                        quest_score += item_is_in_subitem_score;
+                                        score_to_be_added = item_is_in_subitem_score;
                                         break;
                                     case 17:
-                                        quest_score += item_is_in_subitem17_score;
+                                        score_to_be_added = item_is_in_subitem17_score;
                                         break;
                                     case 15:
-                                        quest_score += item_is_in_subitem15_score;
+                                        score_to_be_added = item_is_in_subitem15_score;
                                         break;
                                     default:
-                                        quest_score += item_is_in_subitem_score;
+                                        score_to_be_added = item_is_in_subitem_score;
                                         break;
                                 }
+                                if (priority_items_array.includes(quest_subdrops[i])) { quest_score += score_to_be_added * priority_item_multiplier; }
+                                else { quest_score += score_to_be_added; }
                             }
                         }
                     }
 
                     // CHECK CHARACTER SHARD
-                    if (total_recipe.has(char_shard)) { quest_score += item_is_in_top_2_score; }
+                    if (total_recipe.has(char_shard))
+                    {
+                        if (priority_items_array.includes(char_shard)) { quest_score += item_is_in_top_2_score * priority_item_multiplier; }
+                        else { quest_score += item_is_in_top_2_score; }
+                    }
 
                     // IF QUEST SCORE IS NOT ZERO, ADD TO QUEST TABLE
                     if (quest_score !== 0)
@@ -246,7 +279,9 @@ function build_recommended_quest_table(all_recipe_maps_array)
                 {
                     if (total_recipe.has(char_shard_name))
                     {
-                        table_html += "<img class=\"quest-item-image quest-character-shard\" title=\"" + char_shard_name +
+                        table_html += "<img class=\"quest-item-image quest-character-shard"
+                                + (is_item_a_priority_and_needed(char_shard_name) ? " priority-quest-item" : "")
+                            + "\" title=\"" + char_shard_name +
                             "\" src=\"" + get_item_image_path((char_shard_name).split(' ').join('_')) + "\" alt\"\">";
                         table_html += "<div class=\"quest-character-shard-drop-rate\">" + char_shard_drop_rate + "\u0025</div>";
                     }
@@ -260,22 +295,31 @@ function build_recommended_quest_table(all_recipe_maps_array)
                 table_html += "</th>";
 
                 // ITEM 1 IMAGE
-                table_html += "<th class=\"quest-item-image\" height='48' width='48'>";
-                table_html += "<img class=\"quest-item-image" + (total_recipe.has(item_1_name) ? "" : " grayscale") + "\" title=\"" + item_1_name
+                table_html += "<th height='48'>";
+                table_html += "<img class=\"quest-item-image"
+                        + (total_recipe.has(item_1_name) ? "" : " grayscale")
+                        + (is_item_a_priority_and_needed(item_1_name) && total_recipe.has(item_1_name) ? " priority-quest-item" : "")
+                    + "\" title=\"" + item_1_name
                     + "\" src=\"" + get_item_image_path(item_1_name.split(' ').join('_')) + "\" alt=\"\">";
                 table_html += "<div class=\"quest-percent-text\">" + item_1_drop_percent + "\u0025</div>";
                 table_html += "</th>";
 
                 // ITEM 2 IMAGE
-                table_html += "<th class=\"quest-item-image\" height='48' width='48'>";
-                table_html += "<img class=\"quest-item-image" + (total_recipe.has(item_2_name) ? "" : " grayscale") + "\" title=\"" + item_2_name
+                table_html += "<th height='48'>";
+                table_html += "<img class=\"quest-item-image"
+                        + (total_recipe.has(item_2_name) ? "" : " grayscale")
+                        + (is_item_a_priority_and_needed(item_2_name) && total_recipe.has(item_2_name) ? " priority-quest-item" : "")
+                    + "\" title=\"" + item_2_name
                     + "\" src=\"" + get_item_image_path(item_2_name.split(' ').join('_')) + "\" alt=\"\">";
                 table_html += "<div class=\"quest-percent-text\">" + item_2_drop_percent + "\u0025</div>";
                 table_html += "</th>";
 
                 // ITEM 3 IMAGE
-                table_html += "<th class=\"quest-item-image\" height='48' width='48'>";
-                table_html += "<img class=\"quest-item-image" + (total_recipe.has(item_3_name) ? "" : " grayscale") + "\" title=\"" + item_3_name
+                table_html += "<th height='48'>";
+                table_html += "<img class=\"quest-item-image"
+                        + (total_recipe.has(item_3_name) ? "" : " grayscale")
+                        + (is_item_a_priority_and_needed(item_3_name) && total_recipe.has(item_3_name) ? " priority-quest-item" : "")
+                    + "\" title=\"" + item_3_name
                     + "\" src=\"" + get_item_image_path(item_3_name.split(' ').join('_')) + "\" alt=\"\">";
                 table_html += "<div class=\"quest-percent-text\">" + item_3_drop_percent + "\u0025</div>";
                 table_html += "</th>";
@@ -289,8 +333,11 @@ function build_recommended_quest_table(all_recipe_maps_array)
                 // SUB-ITEM IMAGES
                 for (let i = 0 ; i < subdrops.length ; i++)
                 {
-                    table_html += "<th class=\"quest-item-image\" height='48' width='48'>";
-                    table_html += "<img class=\"quest-item-image" + (total_recipe.has(subdrops[i]) ? "" : " grayscale") + "\" title=\"" + ((subdrops[i] !== "") ? subdrops[i] : "???")
+                    table_html += "<th height='48'>";
+                    table_html += "<img class=\"quest-item-image"
+                            + (total_recipe.has(subdrops[i]) ? "" : " grayscale")
+                            + (is_item_a_priority_and_needed(subdrops[i]) && total_recipe.has(subdrops[i]) ? " priority-quest-item" : "")
+                        + "\" title=\"" + ((subdrops[i] !== "") ? subdrops[i] : "???")
                         + "\" src=\"" + get_item_image_path(((subdrops[i] !== "") ? subdrops[i].split(' ').join('_') : "Placeholder")) + "\" alt=\"\">";
                     if (subdrops_percent === undefined)
                     {
@@ -353,4 +400,51 @@ function refresh_quest_table()
     {
         build_recommended_quest_table(last_compiled_all_recipe_maps_array);
     }
+}
+
+function is_item_a_priority_and_needed(item_name)
+{
+    if (priority_items_array.includes(item_name))
+    {
+        return !disabled_items.includes(item_name);
+    }
+}
+
+function get_priority_items()
+{
+    priority_items_array = [];
+    if (priority_projects.length > 0)
+    {
+        for (let i = 0 ; i < priority_projects.length ; i++)
+        {
+            let project_data = projects.get(priority_projects[i]);
+
+            for (let [item_name, item_amount] of project_data)
+            {
+                let item_recipe = get_recipe(item_name, 1);
+                for (let [component_name, component_amount] of item_recipe)
+                {
+                    if (!priority_items_array.includes(component_name))
+                    {
+                        // INSERT ITEM COMPONENT INTO ARRAY IF IT DOESN'T EXIST ALREADY.
+                        priority_items_array.push(component_name);
+                    }
+                }
+                /*
+
+                 */
+            }
+        }
+    }
+
+    refresh_quest_table();
+
+    // MARK PRIORITY ITEMS AS COMPILED
+    if (!priority_items_compiled)
+    {
+        priority_items_compiled = true;
+    }
+
+    //console.log(JSON.stringify(priority_items_array));
+    //console.log("[Priority Projects] - Priority Item list compiled!");
 }

--- a/scripts/recommended-quest-table.js
+++ b/scripts/recommended-quest-table.js
@@ -430,19 +430,18 @@ function get_priority_items()
                         priority_items_array.push(component_name);
                     }
                 }
-                /*
-
-                 */
             }
         }
     }
-
-    refresh_quest_table();
 
     // MARK PRIORITY ITEMS AS COMPILED
     if (!priority_items_compiled)
     {
         priority_items_compiled = true;
+    }
+    else
+    {
+        refresh_quest_table();
     }
 
     //console.log(JSON.stringify(priority_items_array));

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -336,7 +336,7 @@ function save_cookie()
     settings_map.ignored_rarities = ignored_rarities;
 
     let encrypted_setting_map = JSON.stringify(settings_map);
-    console.log(encrypted_setting_map);
+    //console.log(encrypted_setting_map);
     localStorage.setItem('settings', encrypted_setting_map);
 
     toastr.success((current_language === "en") ? "Your settings have been saved!" : language_json["toasts"]["settings_saved"]);


### PR DESCRIPTION
#### Summary

An attempt at fulfilling the following suggestion: https://github.com/Expugn/priconne-quest-helper/issues/5 .

Prioritizing a project will allow you to focus on a specific project while having other projects be loaded via loading `[All Projects...]` or the `Add Project Items` and `Subtract Project Items` button.

Any item in a `Priority Project` will have its quest score multiplied by `x2.0` and be highlighted red in the `Recommended Quests` section.

`Priority Projects` are also carried over when the `Data Export` feature is used. It will automatically be imported if projects are being imported.

#### Other Information

There are 2 new untranslated text lines:
- `projects_tab.prioritize_project_button`
- `projects_tab.deprioritize_project_button`

While extensive testing has been performed, unknown issues may occur when using this feature so please report them if spotted.

The issue with the website being slower may be problematic due to the amount of (probably) un-optimized calculations being performed. If it is an issue, maybe avoid using the `Priority Project` feature.