### PR TITLE
Add player inventory feature

### DIFF
--- a/css/item_table.css
+++ b/css/item_table.css
@@ -446,7 +446,6 @@ img.quest-character-shard-grayscale {
     position: absolute;
     top: -3px;
 
-    display: block;
     width: 100%;
 
     font-size: 0.5em;

--- a/css/item_table.css
+++ b/css/item_table.css
@@ -367,8 +367,10 @@ img.quest-character-shard-grayscale {
     width: 10px !important;
 }
 
-.quest-hover {
+.quest-hover,
+.quest-item-edit {
     padding-bottom: 0;
+    position: relative;
 }
 
 .quest-req-amount-text {
@@ -394,28 +396,67 @@ img.quest-character-shard-grayscale {
      border-radius: 5px;
  }
 
-.quest-display-top {
+.quest-inv-amount-text {
+     text-shadow: 1px 1px 4px #000000,
+     1px 1px 4px #000000,
+     1px 1px 4px #000000,
+     1px 1px 4px #000000;
+
+     position: absolute;
+     top: 9px;
+     left: 4px;
+
+     color: white;
+     font-family: "Calibri", Arial, serif;
+
+     border-radius: 5px;
+}
+
+.quest-hover.p1 img,
+.quest-hover.p1 .quest-display-top,
+.quest-hover.p1 .quest-display-bottom {
     opacity: 1;
 }
 
-.quest-display-bottom {
-    opacity: 0;
+.quest-hover.p3 img {
+    filter: opacity(30%);
+}
+
+.quest-hover.p3 .quest-display-top,
+.quest-hover.p3 .quest-display-bottom {
+    filter: opacity(50%);
+}
+
+.quest-hover:not(:hover) .quest-display-bottom,
+.quest-hover:hover .quest-display-top,
+.quest-item-edit .quest-percent-text {
+    visibility: hidden;
 }
 
 .quest-hover:hover {
     padding-bottom: 0;
 }
 
-
-.quest-hover:hover .quest-display-top {
-    opacity: 0;
-}
-
-.quest-hover:hover .quest-display-bottom {
-    opacity: 1;
-}
-
 .quest-is-empty-text {
     position: relative;
     bottom: -2px;
+}
+
+.inventory-inline-editor {
+    position: absolute;
+    top: -3px;
+
+    display: block;
+    width: 100%;
+
+    font-size: 0.5em;
+}
+
+.inventory-inline-editor button {
+    display: inline-block;
+    width: 48%;
+    padding: 0;
+
+    font-size: 1em;
+    text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <script src="scripts/read-quest-json.js"></script>
     <script src="scripts/read-character-json.js"></script>
     <script src="scripts/settings.js"></script>
+    <script src="scripts/inventory.js"></script>
     <script src="scripts/sort-options.js"></script>
     <script src="scripts/build-item-table.js"></script>
     <script src="scripts/character-presets.js"></script>
@@ -849,6 +850,10 @@
     <img id="lens-image" class="use-webp" image_folder="webpage" file_name="lens" src_prefix="" src="" alt="">
 </div>
 
+<div id="inventory-inline-editor-prototype" class="inventory-inline-editor" hidden>
+    <button class="minus" value="-30">-30</button><button class="plus" value="+30">+30</button>
+</div>
+
 <!-- RUN JAVASCRIPT -->
 <script>
     loadingToast();
@@ -882,6 +887,7 @@
                 read_cookie();
                 build_item_tables();
                 init_blacklist();
+                init_inventory();
                 init_project_data();
                 build_character_preset_list();
                 update_progress();

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -43,8 +43,15 @@ function inventory_get_fragment_amount(fragment_name) {
     }
 }
 
-// amount - integer
-function inventory_set_fragment_amount(fragment_name, amount) {
+/**
+ * Validate and set inventory amount
+ *
+ * @param {string} fragment_name -
+ * @param {number} amount - new amount to set, should be non-negative
+ * @param {boolean} do_save - serialize the inventory into local storage, or not
+ * @return {number} - actual amount set, guaranteed to be non-negative
+ */
+function inventory_set_fragment_amount(fragment_name, amount, do_save = true) {
 
     if (typeof(amount) !== "number") {
         amount = parseInt(amount, 10);
@@ -55,7 +62,9 @@ function inventory_set_fragment_amount(fragment_name, amount) {
 
     inventory.fragments[fragment_name] = amount;
 
-    inventory_save();
+    if (do_save) {
+        inventory_save();
+    }
 
     return amount;
 }
@@ -69,4 +78,25 @@ function inventory_check_fragment_amount(fragment_name, amount) {
     } else {
         return false;
     }
+}
+
+/**
+ * Remove specified fragments from the inventory
+ *
+ * @param {Map.<string, number>} items - fragment names and quantities to remove
+ */
+function inventory_remove(items) {
+    for (let [name, amount] of items) {
+        if (typeof(amount) !== "number") {
+            amount = parseInt(amount, 10);
+        }
+        if (amount === 0) {
+            continue;
+        }
+
+        let fragments = inventory_get_fragment_amount(name);
+        inventory_set_fragment_amount(name, fragments - amount, false);
+    }
+
+    inventory_save();
 }

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,0 +1,72 @@
+let inventory = {};
+// inventory = {
+//   "fragments": {
+//     "Killer Pencil": 1,
+//   }
+// }
+
+function init_inventory()
+{
+    inventory_load()
+}
+
+function inventory_load()
+{
+    if (typeof(Storage) !== "undefined")
+    {
+        let inventory_json = localStorage.getItem('inventory');
+        if (inventory_json !== null) {
+            inventory = JSON.parse(inventory_json);
+        }
+    }
+    if (inventory.fragments === undefined) {
+        inventory.fragments = {};
+    }
+}
+
+function inventory_save()
+{
+    if (typeof(Storage) !== "undefined")
+    {
+        localStorage.setItem('inventory', JSON.stringify(inventory));
+    }
+}
+
+// fragment_name - en name like in quest_data and character_data
+function inventory_get_fragment_amount(fragment_name) {
+    let fragments = inventory.fragments[fragment_name];
+
+    if (fragments !== undefined) {
+        return fragments;
+    } else {
+        return 0;
+    }
+}
+
+// amount - integer
+function inventory_set_fragment_amount(fragment_name, amount) {
+
+    if (typeof(amount) !== "number") {
+        amount = parseInt(amount, 10);
+    }
+    if (amount < 0) {
+        amount = 0;
+    }
+
+    inventory.fragments[fragment_name] = amount;
+
+    inventory_save();
+
+    return amount;
+}
+
+// Check if there are at least as many fragments in the inventory as specified
+// return bool
+function inventory_check_fragment_amount(fragment_name, amount) {
+    let inv_frag_amount = inventory_get_fragment_amount(fragment_name);
+    if (inv_frag_amount >= amount) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -1,3 +1,5 @@
+const ALL_PROJECTS = "[All Projects...]";
+
 let projects = new Map();
 let priority_projects = [];
 let priority_items_array = [];
@@ -46,7 +48,7 @@ function save_project_data()
     let project_name = tmp.textContent || tmp.innerText || "";
 
     // IF PROJECT NAME ISN'T GIVEN OR IS "[All Projects...]", USE "Untitled"
-    if (project_name === "" || project_name === "[All Projects...]")
+    if (project_name === "" || project_name === ALL_PROJECTS)
     {
         if (projects.has("Untitled"))
         {
@@ -107,7 +109,7 @@ function save_project_data()
     // SET SELECTED PROJECT TO RECENTLY SAVED PROJECT, ALSO ENABLE ADD/SUB BUTTONS AND SHOW PRIORITIZE BUTTON
     document.getElementById("saved-projects-select").value = project_name;
     disable_add_and_sub_buttons(false);
-    disable_complete_project_button(completed_projects.includes(project_name));
+    disable_complete_project_button(true);
     show_prioritize_button(true);
 
     // UPDATE PRIORITY ITEMS
@@ -137,7 +139,7 @@ function load_project_data()
     // CLEAR ALL DATA
     clear_item_table();
 
-    if (project_name !== "[All Projects...]")
+    if (project_name !== ALL_PROJECTS)
     {
         // SET ITEM VALUES
         for (let [item_name, item_amount] of project_data)
@@ -240,7 +242,7 @@ function delete_project_data()
 {
     let project_name = document.getElementById("saved-projects-select").value;
 
-    if (project_name !== "[All Projects...]")
+    if (project_name !== ALL_PROJECTS)
     {
         projects.delete(project_name);
 
@@ -284,7 +286,7 @@ function delete_project_data()
     else
     {
         let translated_toast = language_json["toasts"]["project_deleted"];
-        if (project_name === "[All Projects...]")
+        if (project_name === ALL_PROJECTS)
         {
             translated_toast = translated_toast.replace("${project_name}", language_json["projects_tab"]["all_projects_select_option"]);
         }
@@ -370,7 +372,7 @@ function update_saved_projects_select()
         }
         else
         {
-            document.getElementById("saved-projects-select").value = "[All Projects...]";
+            document.getElementById("saved-projects-select").value = ALL_PROJECTS;
         }
     }
 }
@@ -433,7 +435,7 @@ function update_project_selection()
 {
     let selected_project = document.getElementById("saved-projects-select").value;
 
-    if (selected_project === "[All Projects...]")
+    if (selected_project === ALL_PROJECTS)
     {
         disable_add_and_sub_buttons(true);
     }
@@ -445,7 +447,7 @@ function update_project_selection()
     let is_project_prioritized = priority_projects.includes(selected_project);
     show_prioritize_button(!is_project_prioritized);
 
-    let is_project_complete = completed_projects.includes(selected_project);
+    let is_project_complete = selected_project !== ALL_PROJECTS;
     disable_complete_project_button(is_project_complete);
 
     console.log(get_colored_message("Projects", "Selected ", message_status.INFO) + highlight_code(selected_project) + message_status.INFO + "." +
@@ -509,7 +511,6 @@ function init_blacklist()
             }
             refresh_quest_table();
             update_saved_projects_select();
-            disable_complete_project_button(completed_projects.includes(document.getElementById("saved-projects-select").value));
 
             document.getElementById("blacklist-load-button").title = ((saved_blacklist_array.length > 0) ? button_title_string : "The saved blacklist is empty.");
             console.log(get_colored_message("Blacklist", "User blacklist has been loaded!", message_status.SUCCESS));
@@ -572,7 +573,6 @@ function clear_blacklist()
 
         refresh_quest_table();
         update_saved_projects_select();
-        disable_complete_project_button(false);
 
         if (current_language === language.ENGLISH)
         {
@@ -736,7 +736,7 @@ function show_prioritize_button(true_or_false)
 function prioritize_selected_project(true_or_false)
 {
     let selected_project = document.getElementById("saved-projects-select").value;
-    if (selected_project !== "[All Projects...]")
+    if (selected_project !== ALL_PROJECTS)
     {
         if (true_or_false)
         {

--- a/scripts/recipe-reader.js
+++ b/scripts/recipe-reader.js
@@ -199,7 +199,6 @@ function toggle_enabled_item(item_name)
 
     refresh_quest_table();
     update_saved_projects_select();
-    disable_complete_project_button(completed_projects.includes(document.getElementById("saved-projects-select").value));
     document.getElementById("request-button-" + item_name.split(' ').join('_')).classList.toggle("low-opacity");
 }
 

--- a/scripts/recommended-quest-table.js
+++ b/scripts/recommended-quest-table.js
@@ -121,24 +121,30 @@ function build_recommended_quest_table(all_recipe_maps_array)
                     let quest_score = 0;
 
                     // CHECK ITEM 1 - 3
-                    if (total_recipe.has(item_1_name))
+                    let item_1_amount = total_recipe.get(item_1_name);
+                    if (item_1_amount > 0)
                     {
                         //console.log(item_1_name);
                         if (priority_items_array.includes(item_1_name)) {
                             quest_score += (item_is_in_top_2_score * priority_item_multiplier);
                             //console.log("multiplied.")
                         }
-                        else {
+                        else if (!inventory_check_fragment_amount(item_1_name, item_1_amount)) {
                             quest_score += item_is_in_top_2_score;
-                            //console.log("not multiplied.");
                         }
                     }
-                    if (total_recipe.has(item_2_name))
+
+                    let item_2_amount = total_recipe.get(item_2_name);
+                    if (item_2_amount > 0)
                     {
                         if (priority_items_array.includes(item_2_name)) { quest_score += item_is_in_top_2_score * priority_item_multiplier; }
-                        else { quest_score += item_is_in_top_2_score; }
+                        else if (!inventory_check_fragment_amount(item_2_name, item_2_amount)) {
+                            quest_score += item_is_in_top_2_score;
+                        }
                     }
-                    if (total_recipe.has(item_3_name))
+
+                    let item_3_amount = total_recipe.get(item_3_name);
+                    if (item_3_amount > 0)
                     {
                         let score_to_be_added;
                         // IF ITEM 3 DROP PERCENT == ITEM 1 DROP PERCENT, GIVE SCORE EQUAL AS IF ITEM WAS IN TOP 2
@@ -152,24 +158,34 @@ function build_recommended_quest_table(all_recipe_maps_array)
                         }
 
                         if (priority_items_array.includes(item_3_name)) { quest_score += score_to_be_added * priority_item_multiplier; }
-                        else { quest_score += score_to_be_added; }
+                        else if (!inventory_check_fragment_amount(item_3_name, item_3_amount)) {
+                            quest_score += score_to_be_added;
+                        }
                     }
-                    if (total_recipe.has(item_4_name))
+
+                    let item_4_amount = total_recipe.get(item_4_name);
+                    if (item_4_amount > 0)
                     {
                         // ITEM 4 IS A VERY HARD DIFFICULTY EXCLUSIVE, SO IT WILL ALWAYS BE EQUAL TO ITEMS 1 - 3
                         if (priority_items_array.includes(item_4_name)) { quest_score += (item_is_in_top_2_score * priority_item_multiplier); }
-                        else { quest_score += item_is_in_top_2_score; }
+                        else if (!inventory_check_fragment_amount(item_4_name, item_4_amount)) {
+                            quest_score += item_is_in_top_2_score;
+                        }
                     }
 
                     // CHECK SUBDROPS
                     for (let i = 0 ; i < quest_subdrops.length ; i++)
                     {
-                        if (total_recipe.has(quest_subdrops[i]))
+                        let item_name = quest_subdrops[i];
+                        let item_amount = total_recipe.get(item_name);
+                        if (item_amount > 0)
                         {
                             if (q_subdrops_percent === undefined)
                             {
                                 if (priority_items_array.includes(quest_subdrops[i])) { quest_score += item_is_in_subitem_score * priority_item_multiplier; }
-                                else { quest_score += item_is_in_subitem_score; }
+                                else if (!inventory_check_fragment_amount(item_name, item_amount)) {
+                                    quest_score += item_is_in_subitem_score;
+                                }
                             }
                             else
                             {
@@ -193,7 +209,9 @@ function build_recommended_quest_table(all_recipe_maps_array)
                                         break;
                                 }
                                 if (priority_items_array.includes(quest_subdrops[i])) { quest_score += score_to_be_added * priority_item_multiplier; }
-                                else { quest_score += score_to_be_added; }
+                                else if (!inventory_check_fragment_amount(item_name, item_amount)) {
+                                    quest_score += score_to_be_added;
+                                }
                             }
                         }
                     }
@@ -348,23 +366,32 @@ function build_recommended_quest_table(all_recipe_maps_array)
                 {
                     let item_amount = total_recipe.get(item_name);
                     let is_not_included_in_disabled = !disabled_items.includes(item_name);
+                    let show_text = item_amount > 0 && is_not_included_in_disabled;
+                    let disabled_class = show_text ? "" : " quest-is-empty-text";
 
-                    table_html += "<th class='quest-hover" + ((item_amount > 0 && is_not_included_in_disabled) ? "" : " quest-is-empty-text") + "' height='48'>";
+                    let inv_frag_amount = inventory_get_fragment_amount(item_name);
+                    let priority_class = "p1";
+                    if (!total_recipe.has(item_name) || inv_frag_amount >= item_amount) {
+                        priority_class = "p3";
+                    }
+
+                    table_html += "<th class='quest-hover " + priority_class + disabled_class + "' height='48' data-item-name=\"" + item_name + "\">";
                     table_html += "<img class=\"quest-item-image"
-                        + (total_recipe.has(item_name) ? "" : " grayscale")
                         + (is_item_a_priority_and_needed(item_name) && total_recipe.has(item_name) ? " priority-quest-item" : "")
                         + ((is_item_4) ? " item-4-element" : "")
                         + "\" title=\"" + item_name
                         + "\" src=\"" + get_item_image_path(item_name.split(' ').join('_')) + "\" alt=\"\"" + (is_item_4 ? " hidden" : "")  + ">";
-                    if (item_amount > 0 && is_not_included_in_disabled)
+                    if (show_text)
                     {
                         if (quest_display === quest_display_settings.AMOUNT)
                         {
+                            table_html += "<div class=\"quest-inv-amount-text quest-display-top" + ((is_item_4) ? " item-4-element" : "") + "\">" + "\u00D7" + inv_frag_amount + "</div>";
                             table_html += "<div class=\"quest-percent-text quest-display-bottom" + ((is_item_4) ? " item-4-element" : "") + "\">" + item_drop_percent + "\u0025" + "</div>";
                             table_html += "<div class=\"quest-req-amount-text quest-display-top" + ((is_item_4) ? " item-4-element" : "") + "\">" + "\u00D7" + item_amount + "</div>";
                         }
                         else
                         {
+                            table_html += "<div class=\"quest-inv-amount-text quest-display-bottom" + ((is_item_4) ? " item-4-element" : "") + "\">" + "\u00D7" + inv_frag_amount + "</div>";
                             table_html += "<div class=\"quest-percent-text quest-display-top" + ((is_item_4) ? " item-4-element" : "") + "\">" + item_drop_percent + "\u0025" + "</div>";
                             table_html += "<div class=\"quest-req-amount-text quest-display-bottom" + ((is_item_4) ? " item-4-element" : "") + "\">" + "\u00D7" + item_amount + "</div>";
                         }
@@ -436,18 +463,28 @@ function build_recommended_quest_table(all_recipe_maps_array)
                 // SUB-ITEM IMAGES
                 for (let i = 0 ; i < subdrops.length ; i++)
                 {
+                    let item_name = subdrops[i];
                     let item_amount = total_recipe.get(subdrops[i]);
                     let is_not_included_in_disabled = !disabled_items.includes(subdrops[i]);
-                    table_html += "<th class='quest-hover" + ((item_amount > 0 && is_not_included_in_disabled) ? "" : " quest-is-empty-text") + "' height='48'>";
+                    let show_text = item_amount > 0 && is_not_included_in_disabled;
+                    let disabled_class = show_text ? "" : " quest-is-empty-text";
+                    let inv_frag_amount = inventory_get_fragment_amount(subdrops[i]);
+
+                    let priority_class = "p1";
+                    if (!total_recipe.has(item_name) || inv_frag_amount >= item_amount) {
+                        priority_class = "p3";
+                    }
+
+                    table_html += "<th class='quest-hover " + priority_class + disabled_class + "' height='48' data-item-name=\"" + item_name + "\">";
                     table_html += "<img class=\"quest-item-image"
-                            + (total_recipe.has(subdrops[i]) ? "" : " grayscale")
                             + (is_item_a_priority_and_needed(subdrops[i]) && total_recipe.has(subdrops[i]) ? " priority-quest-item" : "")
                         + "\" title=\"" + ((subdrops[i] !== "") ? subdrops[i] : "???")
                         + "\" src=\"" + get_item_image_path(((subdrops[i] !== "") ? subdrops[i].split(' ').join('_') : "Placeholder")) + "\" alt=\"\">";
-                    if (item_amount > 0 && is_not_included_in_disabled)
+                    if (show_text)
                     {
                         if (quest_display === quest_display_settings.AMOUNT)
                         {
+                            table_html += "<div class=\"quest-inv-amount-text quest-display-top\">" + "\u00D7" + inv_frag_amount + "</div>";
                             if (subdrops_percent === undefined)
                             {
                                 table_html += "<div class=\"quest-percent-text quest-display-bottom\">20\u0025</div>";
@@ -460,6 +497,7 @@ function build_recommended_quest_table(all_recipe_maps_array)
                         }
                         else
                         {
+                            table_html += "<div class=\"quest-inv-amount-text quest-display-bottom\">" + "\u00D7" + inv_frag_amount + "</div>";
                             if (subdrops_percent === undefined)
                             {
                                 table_html += "<div class=\"quest-percent-text quest-display-top\">20\u0025</div>";
@@ -622,3 +660,131 @@ function focus_on_item(item_name, item_id)
     // REFRESH QUESTS
     refresh_quest_table();
 }
+
+$(function() {
+
+    function get_priority_class(inventory_amount, recipe_amount) {
+        let priority_class = "p1";
+        if (inventory_amount >= recipe_amount) {
+            priority_class = "p3";
+        }
+        return priority_class;
+    }
+
+    // hide inline inventory editor and stop editing mode
+    function editor_hide($inventory_editor) {
+
+        $inventory_editor.hide();
+
+        let $current_item_parent = $inventory_editor.parent();
+        if ($current_item_parent.hasClass('quest-item-edit')) {
+            $current_item_parent.removeClass('quest-item-edit').addClass('quest-hover');
+        }
+    }
+
+    // update recommended table after editing is complete:
+    // - redraw the table if scoring changed
+    // - update displayed inventory quantity
+    // - update priority class if priority changed
+    function update_table_after_inventory_change($inventory_editor) {
+        let $current_item_parent = $inventory_editor.parent();
+        let item_name = $current_item_parent.data('item-name');
+        let total_recipe_amount = parseInt($current_item_parent.children('.quest-req-amount-text').text().substring(1));
+        let old_amount = $inventory_editor.data('old-amount');
+        let new_amount = parseInt($current_item_parent.children('.quest-inv-amount-text').text().substring(1));
+
+        let $affected_nodes = $('#recommended-quest-table .quest-hover[data-item-name="' + item_name + '"]');
+        $('.quest-inv-amount-text', $affected_nodes).text('\u00D7' + new_amount);
+
+        let old_priority_class = get_priority_class(old_amount, total_recipe_amount);
+        let new_priority_class = get_priority_class(new_amount, total_recipe_amount);
+
+        if (new_priority_class !== old_priority_class) {
+            if (old_priority_class === "p3" || new_priority_class == "p3") {
+                // here the idea is that only p3 as opposed to p1 and p2 would exclude the item from scoring quests
+                return refresh_quest_table();
+            }
+            $affected_nodes.removeClass(old_priority_class).addClass(new_priority_class);
+        }
+    }
+
+    $('#recommended-quest-table').on('click', '.quest-item-image', function(event) {
+        // open the editor if it's not shown
+        // close it if it's shown on the current item
+        // move it if it's shown on a different item
+
+        event.stopPropagation();
+
+        let $this = $(this);
+
+        let $inventory_editor = $('#inventory-inline-editor');
+        if ($inventory_editor.length === 0) {
+            $inventory_editor = $('#inventory-inline-editor-prototype').clone().prop('id', 'inventory-inline-editor');
+        }
+
+        if ($inventory_editor.is(':visible')) {
+            editor_hide($inventory_editor);
+            update_table_after_inventory_change($inventory_editor);
+
+            if ($this.prev().is($inventory_editor)) {
+                return;
+            }
+        }
+
+        $this.before($inventory_editor);
+
+        let $current_parent = $this.parent();
+        let item_name = $current_parent.data('item-name');
+        let current_amount = inventory_get_fragment_amount(item_name);
+
+        $inventory_editor.data('old-amount', current_amount);
+
+        let increment = equipment_map.get(item_name.replace(' Fragment', '')).get("req_pieces");
+        if (increment < 10) {
+            increment = 10;
+        }
+
+        let $plus_button = $('button.plus', $inventory_editor);
+        $plus_button.text('+' + increment);
+        $plus_button[0].value = '+' + increment;
+
+        let $minus_button = $('button.minus', $inventory_editor);
+        $minus_button.text('-' + increment);
+        $minus_button[0].value = '-' + increment;
+
+        $current_parent.removeClass('quest-hover').addClass('quest-item-edit');
+
+        $inventory_editor.show();
+    });
+
+    $('#recommended-div').on('click', function(event) {
+        // close the editor on clicking away
+
+        let $inventory_editor = $('#inventory-inline-editor');
+        if ($inventory_editor.length !== 0 && $inventory_editor.is(':visible') ) {
+            editor_hide($inventory_editor);
+            update_table_after_inventory_change($inventory_editor);
+        }
+
+        event.stopPropagation();
+    });
+
+    $('#recommended-quest-table').on('click', '#inventory-inline-editor button', function(event) {
+        // add or remove inventory items
+
+        let $this = $(this);
+
+        let $current_parent = $this.parent().parent();
+
+        let item_name = $current_parent.data('item-name');
+
+        let amount = parseInt(this.value);
+
+        let current_amount = inventory_get_fragment_amount(item_name);
+        let new_amount = inventory_set_fragment_amount(item_name, current_amount + amount);
+
+        $('.quest-inv-amount-text', $current_parent).text('\u00D7' + new_amount);
+
+        event.stopPropagation();
+    });
+});

--- a/scripts/recommended-quest-table.js
+++ b/scripts/recommended-quest-table.js
@@ -718,9 +718,6 @@ $(function() {
         let $this = $(this);
 
         let $inventory_editor = $('#inventory-inline-editor');
-        if ($inventory_editor.length === 0) {
-            $inventory_editor = $('#inventory-inline-editor-prototype').clone().prop('id', 'inventory-inline-editor');
-        }
 
         if ($inventory_editor.is(':visible')) {
             editor_hide($inventory_editor);
@@ -729,6 +726,12 @@ $(function() {
             if ($this.prev().is($inventory_editor)) {
                 return;
             }
+        }
+
+        if ($inventory_editor.length === 0) {
+            $inventory_editor = $('#inventory-inline-editor-prototype').clone()
+                .prop('id', 'inventory-inline-editor')
+                .prop('hidden', false);
         }
 
         $this.before($inventory_editor);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -297,7 +297,6 @@ function toggle_ignored_rarity(rarity)
 
     build_data();
     update_saved_projects_select();
-    disable_complete_project_button(completed_projects.includes(document.getElementById("saved-projects-select").value));
 }
 
 function change_display_option()


### PR DESCRIPTION
- show inline inventory editor in recommended quests
- save inventory to local storage
- score quests based on inventory
- show inventory counter in recommended quests

I've kept refactoring to a minimum to simplify reviewing and merging.

Future work:
- add inventory to gist export and import
- adjust inventory when marking project completed
- define an intermediate p2 semi-transparent state e.g. when more than 50% of required fragments are in inventory