### PR TITLE
Added 2x and 3x event selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.4] - 2021-06-14
+### Added
+- 2x and 3x Event Selection
+  - Written by `OrkunKocyigit`: <https://github.com/Expugn/priconne-quest-helper/pull/40>
+  - Modifies quest score depending on selection
+    - `quest_score * 2` if 2x event
+    - `quest_score * 3` if 3x event
+  - Updated Language Files (JP/KR/CN ***MAY BE INCORRECT***)
+    - `settings_tab.normal-quest-drop-event`
+    - `settings_tab.hard-quest-drop-event`
+    - `settings_tab.very-hard-quest-drop-event`
+    - `settings_tab.drop-event-no-buff-select`
+    - `settings_tab.drop-event-double-buff-select`
+    - `settings_tab.drop-event-triple-buff-select`
+  - Changes from initial pull request
+    - Added settings saving and data export/import support
+    - Fix spelling mistake: i.e. `normal_quest_drop_multiplayer` -> `normal_quest_drop_multiplier`
+    - Adjusted spacing of page elements
+    - Change CN's `settings_tab.drop-event-triple-buff-select` from `3 倍掉落量` -> `3x 倍掉落量`
+
 ## [2.13.3] - 2021-06-07
 ### Added
 - New Quest `27-2 VH` (Kurumi)

--- a/index.html
+++ b/index.html
@@ -622,7 +622,7 @@
             <option id="normal-quest-drop-event-triple-buff-option" value="3">Triple Drop Amounts (3x Event)</option>
         </select>
 
-        <br><br>
+        <br>
 
         <label for="hard-quest-drop-event">
             <translate text="settings_tab.hard-quest-drop-event">Hard Quests Drop Buff:</translate>
@@ -633,7 +633,7 @@
             <option id="hard-quest-drop-event-triple-buff-option" value="3">Triple Drop Amounts (3x Event)</option>
         </select>
 
-        <br><br>
+        <br>
 
         <label for="very-hard-quest-drop-event">
             <translate text="settings_tab.very-hard-quest-drop-event">Very Hard Quests Drop Buff:</translate>

--- a/index.html
+++ b/index.html
@@ -613,6 +613,39 @@
 
         <br><br>
 
+        <label for="normal-quest-drop-event">
+            <translate text="settings_tab.normal-quest-drop-event">Normal Quests Drop Buff:</translate>
+        </label>
+        <select id="normal-quest-drop-event" onchange="settings.change_normal_quest_drop_event()">
+            <option id="normal-quest-drop-event-no-buff-option" value="1">Normal Drop Amounts (No Event)</option>
+            <option id="normal-quest-drop-event-double-buff-option" value="2">Double Drop Amounts (2x Event)</option>
+            <option id="normal-quest-drop-event-triple-buff-option" value="3">Triple Drop Amounts (3x Event)</option>
+        </select>
+
+        <br><br>
+
+        <label for="hard-quest-drop-event">
+            <translate text="settings_tab.hard-quest-drop-event">Hard Quests Drop Buff:</translate>
+        </label>
+        <select id="hard-quest-drop-event" onchange="settings.change_hard_quest_drop_event()">
+            <option id="hard-quest-drop-event-no-buff-option" value="1">Normal Drop Amounts (No Event)</option>
+            <option id="hard-quest-drop-event-double-buff-option" value="2">Double Drop Amounts (2x Event)</option>
+            <option id="hard-quest-drop-event-triple-buff-option" value="3">Triple Drop Amounts (3x Event)</option>
+        </select>
+
+        <br><br>
+
+        <label for="very-hard-quest-drop-event">
+            <translate text="settings_tab.very-hard-quest-drop-event">Very Hard Quests Drop Buff:</translate>
+        </label>
+        <select id="very-hard-quest-drop-event" onchange="settings.change_very_hard_quest_drop_event()">
+            <option id="very-hard-quest-drop-event-no-buff-option" value="1">Normal Drop Amounts (No Event)</option>
+            <option id="very-hard-quest-drop-event-double-buff-option" value="2">Double Drop Amounts (2x Event)</option>
+            <option id="very-hard-quest-drop-event-triple-buff-option" value="3">Triple Drop Amounts (3x Event)</option>
+        </select>
+
+        <br><br>
+
         <label for="equipment-data-type">
             <translate text="settings_tab.equipment_data_type_label">Equipment Data Type:</translate>
         </label>

--- a/language/en-US.json
+++ b/language/en-US.json
@@ -115,6 +115,13 @@
     "reset_settings_button": "Reset Settings",
     "display_saved_settings_button": "Read Saved Settings",
 
+    "normal-quest-drop-event": "Normal Quests Drop Buff:",
+    "hard-quest-drop-event": "Hard Quests Drop Buff：",
+    "very-hard-quest-drop-event": "Very Hard Quests Drop Buff：",
+    "drop-event-no-buff-select": "Normal Drop Amounts (No Event)",
+    "drop-event-double-buff-select": "Double Drop Amounts (2x Event)",
+    "drop-event-triple-buff-select": "Double Drop Amounts (3x Event)",
+
     "equipment_data_type_label": "Equipment Data Type:",
     "equipment_data_current_select": "Current Equipment Data (After 2019.08.31)",
     "equipment_data_legacy_select": "Legacy Equipment Data (Before 2019.08.31)"

--- a/language/en-US.json
+++ b/language/en-US.json
@@ -120,7 +120,7 @@
     "very-hard-quest-drop-event": "Very Hard Quests Drop Buff：",
     "drop-event-no-buff-select": "Normal Drop Amounts (No Event)",
     "drop-event-double-buff-select": "Double Drop Amounts (2x Event)",
-    "drop-event-triple-buff-select": "Double Drop Amounts (3x Event)",
+    "drop-event-triple-buff-select": "Triple Drop Amounts (3x Event)",
 
     "equipment_data_type_label": "Equipment Data Type:",
     "equipment_data_current_select": "Current Equipment Data (After 2019.08.31)",

--- a/language/ja-JP.json
+++ b/language/ja-JP.json
@@ -115,6 +115,13 @@
     "reset_settings_button": "設定リセット",
     "display_saved_settings_button": "設定読み込み",
 
+    "normal-quest-drop-event": "通常のクエストドロップバフ：",
+    "hard-quest-drop-event": "ハードクエストドロップバフ：",
+    "very-hard-quest-drop-event": "非常に難しいクエストドロップバフ：",
+    "drop-event-no-buff-select": "ドロップ量通常",
+    "drop-event-double-buff-select": "ドロップ量2倍",
+    "drop-event-triple-buff-select": "ドロップ量3倍",
+
     "equipment_data_type_label": "装備データのタイプ：",
     "equipment_data_current_select": "現在の装備データ (2019.08.31. 以後)",
     "equipment_data_legacy_select": "過去の装備データ (2019.08.31. 以前)"

--- a/language/ko-KR.json
+++ b/language/ko-KR.json
@@ -115,6 +115,13 @@
     "reset_settings_button": "설정 초기화",
     "display_saved_settings_button": "저장된 설정 읽어오기",
 
+    "normal-quest-drop-event": "일반 퀘스트 드롭 버프 :",
+    "hard-quest-drop-event": "하드 퀘스트 드롭 버프 :",
+    "very-hard-quest-drop-event": "매우 어려운 퀘스트 드롭 버프 :",
+    "drop-event-no-buff-select": "일반 드랍 금액",
+    "drop-event-double-buff-select": "드롭 금액 2 배",
+    "drop-event-triple-buff-select": "드롭 금액 3 배",
+
     "equipment_data_type_label": "장비 데이터 종류 :",
     "equipment_data_current_select": "현재 장비 데이터 (2019.08.31. 이후)",
     "equipment_data_legacy_select": "이전 장비 데이터 (2019.08.31. 이전)"

--- a/language/zh-CN.json
+++ b/language/zh-CN.json
@@ -113,6 +113,13 @@
       "reset_settings_button": "重置为默认设置",
       "display_saved_settings_button": "读取已保存的设置",
 
+      "normal-quest-drop-event": "普通任务掉落增益：",
+      "hard-quest-drop-event": "硬任务掉落增益：",
+      "very-hard-quest-drop-event": "非常困难的任务掉落增益：",
+      "drop-event-no-buff-select": "正常掉落量",
+      "drop-event-double-buff-select": "2x 掉落数量",
+      "drop-event-triple-buff-select": "3 倍掉落量",
+
       "equipment_data_type_label": "装备数据类型:",
       "equipment_data_current_select": "当前装备数据 (日服2019.08.31版本之后)",
       "equipment_data_legacy_select": "初版装备数据 (日服2019.08.31版本之前)"

--- a/language/zh-CN.json
+++ b/language/zh-CN.json
@@ -118,7 +118,7 @@
       "very-hard-quest-drop-event": "非常困难的任务掉落增益：",
       "drop-event-no-buff-select": "正常掉落量",
       "drop-event-double-buff-select": "2x 掉落数量",
-      "drop-event-triple-buff-select": "3 倍掉落量",
+      "drop-event-triple-buff-select": "3x 倍掉落量",
 
       "equipment_data_type_label": "装备数据类型:",
       "equipment_data_current_select": "当前装备数据 (日服2019.08.31版本之后)",

--- a/scripts/priconne-quest-helper.js
+++ b/scripts/priconne-quest-helper.js
@@ -26,7 +26,10 @@ const settings = (function () {
         SUBTRACT_AMOUNT_FROM_INVENTORY: "subtract-amount-from-inventory",
         DISPLAY_PRIORITY_ITEM_AMOUNT: "display-priority-item-amount",
         SHOW_PRIORITY_ITEMS_FIRST: "show-priority-items-first",
-        EQUIPMENT_DATA_TYPE: "equipment-data-type"
+        EQUIPMENT_DATA_TYPE: "equipment-data-type",
+        NORMAL_DROP_EVENT: "normal-quest-drop-event",
+        HARD_DROP_EVENT: "hard-quest-drop-event",
+        VERY_HARD_DROP_EVENT: "very-hard-quest-drop-event"
     });
     const tags = Object.freeze({
         QUEST_SHOWN_VALUE: "quest_shown_value",
@@ -60,6 +63,9 @@ const settings = (function () {
         subtract_amount_from_inventory: false,
         display_priority_item_amount: false,
         show_priority_items_first: false,
+        normal_quest_drop_multiplayer: 1,
+        hard_quest_drop_multiplayer: 1,
+        very_hard_quest_drop_multiplayer: 1,
         equipment_data_type: equipment_data.version.CURRENT,
     };
 
@@ -367,6 +373,45 @@ const settings = (function () {
     }
 
     /**
+     * CHANGES AMOUNT OF ITEMS DROP IN NORMAL QUEST MAPS.
+     *      NO EVENT: ITEMS DROP AT NORMAL RATE: 1 ITEM AT A TIME
+     *      2X EVENT: ITEMS DROP AT TWO AT A TIME
+     *      3X EVENT: ITEMS DROP AT THREE AT A TIME
+     * THE QUEST TABLE IS REFRESHED TO REFLECT NEW PRIORITY LIST
+     */
+    function change_normal_quest_drop_event() {
+        settings.normal_quest_drop_multiplayer = Number(document.getElementById(setting_element_id.NORMAL_DROP_EVENT).value);
+        webpage.print("\"Normal Quests Drop Buff\" changed to " + settings.normal_quest_drop_multiplayer, "Settings");
+        data_display.quests.refresh();
+    }
+
+    /**
+     * CHANGES AMOUNT OF ITEMS DROP IN HARD QUEST MAPS.
+     *      NO EVENT: ITEMS DROP AT NORMAL RATE: 1 ITEM AT A TIME
+     *      2X EVENT: ITEMS DROP AT TWO AT A TIME
+     *      3X EVENT: ITEMS DROP AT THREE AT A TIME
+     * THE QUEST TABLE IS REFRESHED TO REFLECT NEW PRIORITY LIST
+     */
+    function change_hard_quest_drop_event() {
+        settings.hard_quest_drop_multiplayer = Number(document.getElementById(setting_element_id.HARD_DROP_EVENT).value);
+        webpage.print("\"Hard Quests Drop Buff\" changed to " + settings.hard_quest_drop_multiplayer, "Settings");
+        data_display.quests.refresh();
+    }
+
+    /**
+     * CHANGES AMOUNT OF ITEMS DROP IN VERY HARD QUEST MAPS.
+     *      NO EVENT: ITEMS DROP AT NORMAL RATE: 1 ITEM AT A TIME
+     *      2X EVENT: ITEMS DROP AT TWO AT A TIME
+     *      3X EVENT: ITEMS DROP AT THREE AT A TIME
+     * THE QUEST TABLE IS REFRESHED TO REFLECT NEW PRIORITY LIST
+     */
+    function change_very_hard_quest_drop_event() {
+        settings.very_hard_quest_drop_multiplayer = Number(document.getElementById(setting_element_id.VERY_HARD_DROP_EVENT).value);
+        webpage.print("\"Very Hard Quests Drop Buff\" changed to " + settings.very_hard_quest_drop_multiplayer, "Settings");
+        data_display.quests.refresh();
+    }
+
+    /**
      * CHANGES THE EQUIPMENT DATA TO CURRENT OR LEGACY.
      *      CURRENT DATA: LATEST UP TO DATE DATA FROM JAPAN SERVER.
      *      LEGACY DATA: RETIRED DATA THAT SOME SERVERS MAY STILL USE THAT HAS HIGHER EQUIPMENT CRAFTING COSTS.
@@ -617,6 +662,9 @@ const settings = (function () {
             subtract_amount_from_inventory: (settings.subtract_amount_from_inventory === undefined ? settings_default.subtract_amount_from_inventory : settings.subtract_amount_from_inventory),
             display_priority_item_amount: (settings.display_priority_item_amount === undefined ? settings_default.display_priority_item_amount : settings.display_priority_item_amount),
             show_priority_items_first: (settings.show_priority_items_first === undefined ? settings_default.show_priority_items_first : settings.show_priority_items_first),
+            normal_quest_drop_multiplayer: (settings.normal_quest_drop_multiplayer === undefined ? settings_default.normal_quest_drop_multiplayer : settings.normal_quest_drop_multiplayer),
+            hard_quest_drop_multiplayer: (settings.hard_quest_drop_multiplayer === undefined ? settings_default.hard_quest_drop_multiplayer : settings.hard_quest_drop_multiplayer),
+            very_hard_quest_drop_multiplayer: (settings.very_hard_quest_drop_multiplayer === undefined ? settings_default.very_hard_quest_drop_multiplayer : settings.very_hard_quest_drop_multiplayer),
             equipment_data_type: (settings.equipment_data_type === undefined ? settings_default.equipment_data_type : settings.equipment_data_type),
         };
     }
@@ -660,6 +708,11 @@ const settings = (function () {
         toggle_subtract_amount_from_inventory: toggle_subtract_amount_from_inventory,
         toggle_display_priority_item_amount: toggle_display_priority_item_amount,
         toggle_show_priority_items_first: toggle_show_priority_items_first,
+
+        change_normal_quest_drop_event: change_normal_quest_drop_event,
+        change_hard_quest_drop_event: change_hard_quest_drop_event,
+        change_very_hard_quest_drop_event: change_very_hard_quest_drop_event,
+
         change_equipment_data: change_equipment_data,
 
         save_settings: save_settings,
@@ -3963,6 +4016,13 @@ const data_display = (function () {
                         }
 
                         if (quest_score > 0) {
+                            if (is_normal) {
+                                quest_score *= setting.normal_quest_drop_multiplayer;
+                            } else if (is_hard) {
+                                quest_score *= setting.hard_quest_drop_multiplayer;
+                            } else if (is_very_hard) {
+                                quest_score *= setting.very_hard_quest_drop_multiplayer;
+                            }
                             quest_score /= quest_info["stamina"];
                             quest_scores.push([quest_id, +quest_score.toFixed(2)]);
                         }
@@ -4492,6 +4552,17 @@ const webpage = (function () {
             else {
                 document.getElementById("translator-footer").innerHTML = "";
             }
+
+            // UPDATE DROP EVENT SETTING CHOICES
+            document.getElementById("normal-quest-drop-event-no-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-no-buff-select"];
+            document.getElementById("normal-quest-drop-event-double-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-double-buff-select"];
+            document.getElementById("normal-quest-drop-event-triple-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-triple-buff-select"];
+            document.getElementById("hard-quest-drop-event-no-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-no-buff-select"];
+            document.getElementById("hard-quest-drop-event-double-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-double-buff-select"];
+            document.getElementById("hard-quest-drop-event-triple-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-triple-buff-select"];
+            document.getElementById("very-hard-quest-drop-event-no-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-no-buff-select"];
+            document.getElementById("very-hard-quest-drop-event-double-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-double-buff-select"];
+            document.getElementById("very-hard-quest-drop-event-triple-buff-option").innerHTML = data[tags.SETTINGS_TAB]["drop-event-triple-buff-select"];
 
             // UPDATE EQUIPMENT DATA TYPE SETTING CHOICES
             document.getElementById("equipment-data-type-current-option").innerHTML = data[tags.SETTINGS_TAB]["equipment_data_current_select"];

--- a/scripts/priconne-quest-helper.js
+++ b/scripts/priconne-quest-helper.js
@@ -26,10 +26,10 @@ const settings = (function () {
         SUBTRACT_AMOUNT_FROM_INVENTORY: "subtract-amount-from-inventory",
         DISPLAY_PRIORITY_ITEM_AMOUNT: "display-priority-item-amount",
         SHOW_PRIORITY_ITEMS_FIRST: "show-priority-items-first",
-        EQUIPMENT_DATA_TYPE: "equipment-data-type",
         NORMAL_DROP_EVENT: "normal-quest-drop-event",
         HARD_DROP_EVENT: "hard-quest-drop-event",
-        VERY_HARD_DROP_EVENT: "very-hard-quest-drop-event"
+        VERY_HARD_DROP_EVENT: "very-hard-quest-drop-event",
+        EQUIPMENT_DATA_TYPE: "equipment-data-type"
     });
     const tags = Object.freeze({
         QUEST_SHOWN_VALUE: "quest_shown_value",
@@ -45,6 +45,9 @@ const settings = (function () {
         SUBTRACT_AMOUNT_FROM_INVENTORY: "subtract_amount_from_inventory",
         DISPLAY_PRIORITY_ITEM_AMOUNT: "display_priority_item_amount",
         SHOW_PRIORITY_ITEMS_FIRST: "show_priority_items_first",
+        NORMAL_DROP_EVENT: "normal_drop_multiplier",
+        HARD_DROP_EVENT: "hard_drop_multiplier",
+        VERY_HARD_DROP_EVENT: "very_hard_drop_multiplier",
         EQUIPMENT_DATA_TYPE: "equipment_data_type"
     });
     const LOCALSTORAGE_KEY = "settings";
@@ -63,9 +66,9 @@ const settings = (function () {
         subtract_amount_from_inventory: false,
         display_priority_item_amount: false,
         show_priority_items_first: false,
-        normal_quest_drop_multiplayer: 1,
-        hard_quest_drop_multiplayer: 1,
-        very_hard_quest_drop_multiplayer: 1,
+        normal_quest_drop_multiplier: 1,
+        hard_quest_drop_multiplier: 1,
+        very_hard_quest_drop_multiplier: 1,
         equipment_data_type: equipment_data.version.CURRENT,
     };
 
@@ -118,6 +121,13 @@ const settings = (function () {
 
         settings_default.show_priority_items_first = document.getElementById(setting_element_id.SHOW_PRIORITY_ITEMS_FIRST).checked;
         settings.show_priority_items_first = settings_default.show_priority_items_first;
+
+        settings_default.normal_quest_drop_multiplier = document.getElementById(setting_element_id.NORMAL_DROP_EVENT).value;
+        settings.normal_quest_drop_multiplier = settings_default.normal_quest_drop_multiplier;
+        settings_default.hard_quest_drop_multiplier = document.getElementById(setting_element_id.HARD_DROP_EVENT).value;
+        settings.hard_quest_drop_multiplier = settings_default.hard_quest_drop_multiplier;
+        settings_default.very_hard_quest_drop_multiplier = document.getElementById(setting_element_id.VERY_HARD_DROP_EVENT).value;
+        settings.very_hard_quest_drop_multiplier = settings_default.very_hard_quest_drop_multiplier;
 
         if (document.getElementById(setting_element_id.EQUIPMENT_DATA_TYPE).value === equipment_data.version.LEGACY) {
             settings_default.equipment_data_type = equipment_data.version.LEGACY
@@ -380,8 +390,8 @@ const settings = (function () {
      * THE QUEST TABLE IS REFRESHED TO REFLECT NEW PRIORITY LIST
      */
     function change_normal_quest_drop_event() {
-        settings.normal_quest_drop_multiplayer = Number(document.getElementById(setting_element_id.NORMAL_DROP_EVENT).value);
-        webpage.print("\"Normal Quests Drop Buff\" changed to " + settings.normal_quest_drop_multiplayer, "Settings");
+        settings.normal_quest_drop_multiplier = Number(document.getElementById(setting_element_id.NORMAL_DROP_EVENT).value);
+        webpage.print("\"Normal Quests Drop Buff\" changed to " + settings.normal_quest_drop_multiplier, "Settings");
         data_display.quests.refresh();
     }
 
@@ -393,8 +403,8 @@ const settings = (function () {
      * THE QUEST TABLE IS REFRESHED TO REFLECT NEW PRIORITY LIST
      */
     function change_hard_quest_drop_event() {
-        settings.hard_quest_drop_multiplayer = Number(document.getElementById(setting_element_id.HARD_DROP_EVENT).value);
-        webpage.print("\"Hard Quests Drop Buff\" changed to " + settings.hard_quest_drop_multiplayer, "Settings");
+        settings.hard_quest_drop_multiplier = Number(document.getElementById(setting_element_id.HARD_DROP_EVENT).value);
+        webpage.print("\"Hard Quests Drop Buff\" changed to " + settings.hard_quest_drop_multiplier, "Settings");
         data_display.quests.refresh();
     }
 
@@ -406,8 +416,8 @@ const settings = (function () {
      * THE QUEST TABLE IS REFRESHED TO REFLECT NEW PRIORITY LIST
      */
     function change_very_hard_quest_drop_event() {
-        settings.very_hard_quest_drop_multiplayer = Number(document.getElementById(setting_element_id.VERY_HARD_DROP_EVENT).value);
-        webpage.print("\"Very Hard Quests Drop Buff\" changed to " + settings.very_hard_quest_drop_multiplayer, "Settings");
+        settings.very_hard_quest_drop_multiplier = Number(document.getElementById(setting_element_id.VERY_HARD_DROP_EVENT).value);
+        webpage.print("\"Very Hard Quests Drop Buff\" changed to " + settings.very_hard_quest_drop_multiplier, "Settings");
         data_display.quests.refresh();
     }
 
@@ -559,6 +569,9 @@ const settings = (function () {
         check_checkbox(setting_element_id.SUBTRACT_AMOUNT_FROM_INVENTORY, settings.subtract_amount_from_inventory);
         check_checkbox(setting_element_id.DISPLAY_PRIORITY_ITEM_AMOUNT, settings.display_priority_item_amount);
         check_checkbox(setting_element_id.SHOW_PRIORITY_ITEMS_FIRST, settings.show_priority_items_first);
+        document.getElementById(setting_element_id.NORMAL_DROP_EVENT).value = settings.normal_quest_drop_multiplier;
+        document.getElementById(setting_element_id.HARD_DROP_EVENT).value = settings.hard_quest_drop_multiplier;
+        document.getElementById(setting_element_id.VERY_HARD_DROP_EVENT).value = settings.very_hard_quest_drop_multiplier;
         document.getElementById(setting_element_id.EQUIPMENT_DATA_TYPE).value = ((settings.equipment_data_type === equipment_data.version.LEGACY) ? equipment_data.version.LEGACY : equipment_data.version.CURRENT);
     }
 
@@ -662,9 +675,9 @@ const settings = (function () {
             subtract_amount_from_inventory: (settings.subtract_amount_from_inventory === undefined ? settings_default.subtract_amount_from_inventory : settings.subtract_amount_from_inventory),
             display_priority_item_amount: (settings.display_priority_item_amount === undefined ? settings_default.display_priority_item_amount : settings.display_priority_item_amount),
             show_priority_items_first: (settings.show_priority_items_first === undefined ? settings_default.show_priority_items_first : settings.show_priority_items_first),
-            normal_quest_drop_multiplayer: (settings.normal_quest_drop_multiplayer === undefined ? settings_default.normal_quest_drop_multiplayer : settings.normal_quest_drop_multiplayer),
-            hard_quest_drop_multiplayer: (settings.hard_quest_drop_multiplayer === undefined ? settings_default.hard_quest_drop_multiplayer : settings.hard_quest_drop_multiplayer),
-            very_hard_quest_drop_multiplayer: (settings.very_hard_quest_drop_multiplayer === undefined ? settings_default.very_hard_quest_drop_multiplayer : settings.very_hard_quest_drop_multiplayer),
+            normal_quest_drop_multiplier: (settings.normal_quest_drop_multiplier === undefined ? settings_default.normal_quest_drop_multiplier : settings.normal_quest_drop_multiplier),
+            hard_quest_drop_multiplier: (settings.hard_quest_drop_multiplier === undefined ? settings_default.hard_quest_drop_multiplier : settings.hard_quest_drop_multiplier),
+            very_hard_quest_drop_multiplier: (settings.very_hard_quest_drop_multiplier === undefined ? settings_default.very_hard_quest_drop_multiplier : settings.very_hard_quest_drop_multiplier),
             equipment_data_type: (settings.equipment_data_type === undefined ? settings_default.equipment_data_type : settings.equipment_data_type),
         };
     }
@@ -4016,13 +4029,16 @@ const data_display = (function () {
                         }
 
                         if (quest_score > 0) {
+                            // 2x/3x EVENT ; MODIFY QUEST SCORE AS NEEDED
                             if (is_normal) {
-                                quest_score *= setting.normal_quest_drop_multiplayer;
+                                quest_score *= setting.normal_quest_drop_multiplier;
                             } else if (is_hard) {
-                                quest_score *= setting.hard_quest_drop_multiplayer;
+                                quest_score *= setting.hard_quest_drop_multiplier;
                             } else if (is_very_hard) {
-                                quest_score *= setting.very_hard_quest_drop_multiplayer;
+                                quest_score *= setting.very_hard_quest_drop_multiplier;
                             }
+
+                            // CALCULATE QUEST SCORE
                             quest_score /= quest_info["stamina"];
                             quest_scores.push([quest_id, +quest_score.toFixed(2)]);
                         }


### PR DESCRIPTION
#### Summary
Hello,
I have added selector for 2x and 3x events in Priconne. It basically multiply quest score by the event amount in order to reflect farming event stages where it is more optimal.

I tried to fit coding style to yours as much as possible.

#### Other Information
Any language other than "en" is done by machine translation.